### PR TITLE
test email changes

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -66,33 +66,33 @@ jobs:
               echo "$merge_log" >> $GITHUB_ENV
               echo 'EOF' >> $GITHUB_ENV
                  
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v34
-        with:
-          separator: "," 
-      # tj-actions' limitation prevents the user from using "\n" as output seperator.
-      # Solution: parse the list of changed files and replace each comma delimiter with a <br>.   
-      - name: Parse changed files
-        id: parsed-output
-        run: |      
-              modified="$(echo  ${{steps.changed-files.outputs.modified_files}} |  sed -e $'s/\,/\\n/g' )"
-                echo "$modified" 
-                echo 'MODIFIED<<EOF' >> $GITHUB_ENV
-                echo "$modified" >> $GITHUB_ENV
-                echo 'EOF' >> $GITHUB_ENV
+      # - name: Get changed files
+      #   id: changed-files
+      #   uses: tj-actions/changed-files@v34
+      #   with:
+      #     separator: "," 
+      # # tj-actions' limitation prevents the user from using "\n" as output seperator.
+      # # Solution: parse the list of changed files and replace each comma delimiter with a <br>.   
+      # - name: Parse changed files
+      #   id: parsed-output
+      #   run: |      
+      #         modified="$(echo  ${{steps.changed-files.outputs.modified_files}} |  sed -e $'s/\,/\\n/g' )"
+      #           echo "$modified" 
+      #           echo 'MODIFIED<<EOF' >> $GITHUB_ENV
+      #           echo "$modified" >> $GITHUB_ENV
+      #           echo 'EOF' >> $GITHUB_ENV
 
-                added='$(echo  ${{steps.changed-files.outputs.added_files}} |  sed -e $'s/\,/\\n/g' )'
-                echo "$added" 
-                echo 'ADDED<<EOF' >> $GITHUB_ENV
-                echo "$ADDED" >> $GITHUB_ENV
-                echo 'EOF' >> $GITHUB_ENV
+      #           added='$(echo  ${{steps.changed-files.outputs.added_files}} |  sed -e $'s/\,/\\n/g' )'
+      #           echo "$added" 
+      #           echo 'ADDED<<EOF' >> $GITHUB_ENV
+      #           echo "$ADDED" >> $GITHUB_ENV
+      #           echo 'EOF' >> $GITHUB_ENV
 
-                deleted=$(echo  ${{steps.changed-files.outputs.deleted_files}} |  sed -e $'s/\,/\\n/g' )
-                echo "$deleted" 
-                echo 'DELETED<<EOF' >> $GITHUB_ENV
-                echo "$deleted" >> $GITHUB_ENV
-                echo 'EOF' >> $GITHUB_ENV
+      #           deleted=$(echo  ${{steps.changed-files.outputs.deleted_files}} |  sed -e $'s/\,/\\n/g' )
+      #           echo "$deleted" 
+      #           echo 'DELETED<<EOF' >> $GITHUB_ENV
+      #           echo "$deleted" >> $GITHUB_ENV
+      #           echo 'EOF' >> $GITHUB_ENV
  
 
       - name: Send mail  
@@ -125,12 +125,12 @@ jobs:
                           
               Compare: ${{env.COMPARE_URL}} 
               Diff: ${{github.event.pull_request.diff_url}}
-              Modified Files: 
-                   ${{env.MODIFIED}} 
-              Added Files:
-                   ${{env.ADDED}} 
-              Removed Files:   
-                   ${{env.DELETED}} 
+              # Modified Files: 
+              #      ${{env.MODIFIED}} 
+              # Added Files:
+              #      ${{env.ADDED}} 
+              # Removed Files:   
+              #      ${{env.DELETED}} 
 
            # Optional converting Markdown to HTML (set content_type to text/html too):
            convert_markdown: false


### PR DESCRIPTION
The below message is copied from chapel-lang. 

This is to test the log formatting.

, it seems that when we initialize a variable whose
type is `: domain` (currently, the completely generic domain type
specifier), we don't do anything to verify that the initializing
expression actually is a domain, and the variable ends up simply taking
on its type. For example, `var d: domain = 3.14;` would compile and `d`
would have type `real`.

From the little bit of testing I've done, this seems like a gap that's
specific to `domain`, which is to say, I'm not seeing similar problems
for generic classes or records. This is likely due to its special
handling in the compiler. It's also somewhat of an effect of our not
(yet, completely) using copy initializers for domains.

Here, I've addressed this by adding a check to a part of the resolution
pass that's reasoning about source/destination types in initializers—and
domain destination types in particular—to check and make sure the RHS
expression is a domain as well, and to generate an error if not. Happily
this didn't trip over any code in our test system that was relying on
the loophole that's existed.

Resolves https://github.com/chapel-lang/chapel/issues/21537.